### PR TITLE
port fwd

### DIFF
--- a/changelog/v0.5.1/curl-port-forward.yaml
+++ b/changelog/v0.5.1/curl-port-forward.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/valet/issues/154
+    description: Support curls that are wrapped with a Kubernetes port-forward.

--- a/cli/internal/ensure/cmd/commands.go
+++ b/cli/internal/ensure/cmd/commands.go
@@ -77,6 +77,7 @@ type CommandStreamHandler struct {
 	WaitFunc func() error
 	Stdout   io.Reader
 	Stderr   io.Reader
+	Process  *exec.Cmd
 }
 
 func (c *CommandStreamHandler) StreamHelper(inputErr error) error {
@@ -119,6 +120,7 @@ func (r *commandRunner) Stream(ctx context.Context, c *Command) (*CommandStreamH
 		},
 		Stdout: outReader,
 		Stderr: errReader,
+		Process: cmd,
 	}, nil
 }
 

--- a/cli/internal/ensure/resource/workflow/curl.go
+++ b/cli/internal/ensure/resource/workflow/curl.go
@@ -112,7 +112,7 @@ func (c *Curl) doCurl(ctx context.Context, input render.InputParams) error {
 		cmd.Stdout().Println("Curl successful")
 		return nil
 	}, retry.Delay(delay), retry.Attempts(uint(c.Attempts)), retry.DelayType(retry.FixedDelay), retry.LastErrorOnly(true))
-	
+
 	if portForwardCmd != nil {
 		_ = portForwardCmd.Process.Process.Kill()
 	}

--- a/cli/internal/ensure/resource/workflow/curl.go
+++ b/cli/internal/ensure/resource/workflow/curl.go
@@ -18,6 +18,8 @@ import (
 const (
 	DefaultCurlDelay    = "1s"
 	DefaultCurlAttempts = 10
+	DefaultMethod = "GET"
+	DefaultPortForwardPort = 8080
 )
 
 var (
@@ -152,9 +154,9 @@ func (c *Curl) GetHttpRequest(url string) (*http.Request, error) {
 }
 
 type PortForward struct {
-	Namespace      string `json:"namespace"`
+	Namespace      string `json:"namespace" valet:"key=Namespace"`
 	DeploymentName string `json:"deploymentName"`
-	Port           int    `json:"port"`
+	Port           int    `json:"port" valet:"default=8080"`
 }
 
 func (p *PortForward) Initiate(ctx context.Context, input render.InputParams) (*cmd.CommandStreamHandler, error) {

--- a/cli/internal/ensure/resource/workflow/curl_test.go
+++ b/cli/internal/ensure/resource/workflow/curl_test.go
@@ -63,7 +63,7 @@ var _ = Describe("curl", func() {
 			StatusCode:   statusCode,
 			ResponseBody: responseBody,
 			Headers:      headers,
-			Service: workflow.ServiceRef{
+			Service: &workflow.ServiceRef{
 				Name:      serviceName,
 				Namespace: serviceNamespace,
 				Port:      servicePort,

--- a/cli/internal/ensure/resource/workflow/curl_test.go
+++ b/cli/internal/ensure/resource/workflow/curl_test.go
@@ -2,6 +2,7 @@ package workflow_test
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -72,9 +73,11 @@ var _ = Describe("curl", func() {
 			Delay:    delay,
 		}
 
+		fullUrl := fmt.Sprintf("%s://%s%s", servicePort, ip, path)
+
 		It("works for expected curl", func() {
 			ingressClient.EXPECT().GetIngressHost(serviceName, serviceNamespace, servicePort).Return(ip, nil).Times(1)
-			req, err := curl.GetHttpRequest(ip)
+			req, err := curl.GetHttpRequest(fullUrl)
 			Expect(err).To(BeNil())
 			runner.EXPECT().Request(ctx, gomock.Eq(req)).Return(responseBody, statusCode, nil)
 			err = curl.Ensure(ctx, input)
@@ -83,7 +86,7 @@ var _ = Describe("curl", func() {
 
 		It("returns error for unexpected response body", func() {
 			ingressClient.EXPECT().GetIngressHost(serviceName, serviceNamespace, servicePort).Return(ip, nil).Times(1)
-			req, err := curl.GetHttpRequest(ip)
+			req, err := curl.GetHttpRequest(fullUrl)
 			Expect(err).To(BeNil())
 			runner.EXPECT().Request(ctx, gomock.Eq(req)).Return(otherResponseBody, statusCode, nil).Times(attempts)
 			err = curl.Ensure(ctx, input)
@@ -93,7 +96,7 @@ var _ = Describe("curl", func() {
 
 		It("returns error for unexpected status code", func() {
 			ingressClient.EXPECT().GetIngressHost(serviceName, serviceNamespace, servicePort).Return(ip, nil).Times(1)
-			req, err := curl.GetHttpRequest(ip)
+			req, err := curl.GetHttpRequest(fullUrl)
 			Expect(err).To(BeNil())
 			runner.EXPECT().Request(ctx, gomock.Eq(req)).Return(responseBody, otherStatusCode, nil).Times(attempts)
 			err = curl.Ensure(ctx, input)
@@ -103,7 +106,7 @@ var _ = Describe("curl", func() {
 
 		It("returns error for request error", func() {
 			ingressClient.EXPECT().GetIngressHost(serviceName, serviceNamespace, servicePort).Return(ip, nil).Times(1)
-			req, err := curl.GetHttpRequest(ip)
+			req, err := curl.GetHttpRequest(fullUrl)
 			Expect(err).To(BeNil())
 			runner.EXPECT().Request(ctx, gomock.Eq(req)).Return(responseBody, statusCode, emptyErr).Times(attempts)
 			err = curl.Ensure(ctx, input)
@@ -118,16 +121,23 @@ var _ = Describe("curl", func() {
 	})
 
 	Context("curl default rendering", func() {
-		curl := workflow.Curl{}
+		curl := workflow.Curl{
+			Service: &workflow.ServiceRef{},
+			PortForward: &workflow.PortForward{},
+		}
 
 		It("works", func() {
 			err := input.RenderFields(&curl)
 			Expect(err).To(BeNil())
-			err = input.RenderFields(&curl.Service)
+			err = input.RenderFields(curl.Service)
+			Expect(err).To(BeNil())
+			err = input.RenderFields(curl.PortForward)
 			Expect(err).To(BeNil())
 			Expect(curl.Attempts).To(Equal(workflow.DefaultCurlAttempts))
 			Expect(curl.Delay).To(Equal(workflow.DefaultCurlDelay))
+			Expect(curl.Method).To(Equal(workflow.DefaultMethod))
 			Expect(curl.Service.Port).To(Equal(workflow.DefaultServicePort))
+			Expect(curl.PortForward.Port).To(Equal(workflow.DefaultPortForwardPort))
 		})
 	})
 


### PR DESCRIPTION
For example, here's a quick valet workflow for setting up debug logging on a gloo pod: 

```
steps:
  - curl:
      method: PUT
      body: '{ "level": "debug" }'
      statusCode: 200
      path: /logging
      portForward:
        deploymentName: extauth
        namespace: gloo-system
        port: 9091
```

Result:
```
[2020-03-30T17:15:39-04:00] Initiated port forward
[2020-03-30T17:15:39-04:00] Curling http://localhost:9091/logging: {host: , headers: map[], expectedStatus: 200}
[2020-03-30T17:15:39-04:00] Forwarding from 127.0.0.1:9091 -> 9091
[2020-03-30T17:15:39-04:00] Forwarding from [::1]:9091 -> 9091
[2020-03-30T17:15:40-04:00] Handling connection for 9091
[2020-03-30T17:15:40-04:00] Curl successful
[2020-03-30T17:15:40-04:00] Workflow successful, cleaning up
```

BOT NOTES: 
resolves https://github.com/solo-io/valet/issues/154